### PR TITLE
README: Link to standards in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Drone industry standards for hardware and electronics. The drone standards (DS) documents are organized as follows:
 
  - DS-001-008: Reserved for future use
- - DS-009: Pixhawk Connector Standard
- - DS-010: Pixhawk Autopilot Bus Standard
- - DS-011: Pixhawk Autopilot v5X Standard
- - DS-012: Pixhawk Autopilot v6X Standard (in draft)
+ - [DS-009: Pixhawk Connector Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-009%20Pixhawk%20Connector%20Standard.pdf)
+ - [DS-010: Pixhawk Autopilot Bus Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-010%20Pixhawk%20Autopilot%20Bus%20Standard.pdf)
+ - [DS-011: Pixhawk Autopilot v5X Standard](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-011%20Pixhawk%20Autopilot%20v5X%20Standard.pdf)
+ - [DS-012: Pixhawk Autopilot v6X Standard (in draft)](https://github.com/pixhawk/Pixhawk-Standards/blob/master/DS-012%20Pixhawk%20Autopilot%20v6X%20Standard.pdf)
  - DS-013: Pixhawk Smart Battery Standard (in draft)
  - DS-014: Pixhawk Payload Bus Standard (in draft)


### PR DESCRIPTION
Makes it easy to use, and immediately highlights which are not present in the repo.