### PR TITLE
Add new FMU to revisions

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -112,7 +112,7 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x002 | resistors |     |
 | 0x003 | resistors | Holybro FMUv6x rev3 |
 | 0x004 | resistors | Holybro FMUv6x rev4 |
-| 0x005 | resistors |     |
+| 0x005 | resistors | ClearSky AVEGA (FMUv6X) |
 | 0x006 | resistors |     |
 | 0x007 | resistors | Read Revision from EEPROM |
 | 0x009 | resistors |     |


### PR DESCRIPTION
Hello!
I'm from the ClearSky company. We are starting to develop an autopilot according to the Pixhawk v6X standard and I would like to reserve a revision number