### PR TITLE
Add new REV6 FMU to revisions

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -98,6 +98,7 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x005 | resistors |     |
 | 0x006 | resistors |     |
 | 0x007 | resistors | Read Revision from EEPROM |
+| 0x008 | resistors |     |
 | 0x009 | resistors |     |
 | 0x00a | resistors |     |
 | 0x010 | EEPROM |     |
@@ -113,8 +114,9 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x003 | resistors | Holybro FMUv6x rev3 |
 | 0x004 | resistors | Holybro FMUv6x rev4 |
 | 0x005 | resistors | ClearSky AVEGA (FMUv6X) |
-| 0x006 | resistors |     |
+| 0x006 | resistors | Holybro FMUv6x rev6 |
 | 0x007 | resistors | Read Revision from EEPROM |
+| 0x008 | resistors |     |
 | 0x009 | resistors |     |
 | 0x00a | resistors |     |
 | 0x010 | EEPROM | Auterion FMUv6x 0.6.0  |


### PR DESCRIPTION
Add Holybro REV6 IMU set to FMUv6X.
Add 0x008 that was previously missing. 