### PR TITLE
Add Skynode Lite base board version

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -156,6 +156,7 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x009 | resistors | Auterion Skynode base RC9 & older (no usb) |
 | 0x00a | resistors | Skynode QS no USB |
 | 0x010 | EEPROM | Auterion Skynode RC10, RC11, RC12, RC13 |
+| 0x011 | EEPROM | Auterion Skynode Lite RC13 |
 | 0x100 | EEPROM | Holybro Pixhawk Jetson Baseboard |
 
 ### FMU v5x revisions


### PR DESCRIPTION
A stripped down version of Skynode RC13 without PX4IO and other components missing.