### PR TITLE
add amovlab icf6  Baseboard

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -159,6 +159,7 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x011 | EEPROM | Auterion Skynode Lite RC13 |
 | 0x100 | EEPROM | Holybro Pixhawk Jetson Baseboard |
 | 0x150 | EEPROM | ZeroOne X6 Baseboard |
+| 0x151 | EEPROM |Amovlab ICF6 Baseboard|
 
 ### FMU v5x revisions
 


### PR DESCRIPTION
Dear developers, we plan to use No pop for the resistor on the FMU board and EEPROM code on the baseboard. I have modified the bottom line, please help review it.

| 0x151 | EEPROM |Amovlab ICF6 Baseboard|