### PR TITLE
Update DS-019 Pixhawk versions and revisions.md

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -195,4 +195,4 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x009 | resistors |     |
 | 0x00a | resistors |     |
 | 0x010 | EEPROM | Auterion FMUv6x 0.6.0  |
-
+| 0x011 | EEPROM | Accton Godwit FMUv6x G-A1 |


### PR DESCRIPTION
Request for a new imu board id.

HEX board ID: 0x011
Board Name: godwit-ga1
Board Type: imu
Manufacturer Name: Accton
Manufacturer Email: support@accton-iot.com