### PR TITLE
DS-019: Add NewBeeDrone Pixhawk 6X Pro Board

### DIFF
--- a/DS-019 Pixhawk versions and revisions.md
+++ b/DS-019 Pixhawk versions and revisions.md
@@ -160,7 +160,7 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x100 | EEPROM | Holybro Pixhawk Jetson Baseboard |
 | 0x150 | EEPROM | ZeroOne X6 Baseboard |
 | 0x200 | EEPROM | Amovlab ICF6 Baseboard |
-
+| 0x300 | EEPROM | NewBeeDrone Pixhawk 6X Baseboard |
 ### FMU v5x revisions
 
 |     |     |     |
@@ -196,4 +196,4 @@ HWTYPE = {v5/6x}{VER}{REV}
 | 0x009 | resistors |     |
 | 0x00a | resistors |     |
 | 0x010 | EEPROM | Auterion FMUv6x 0.6.0  |
-
+| 0x300 | EEPROM | NewBeeDrone FMUv6x revA |


### PR DESCRIPTION
Hi, we would like to request EEPROM entries for both the IMU board and the baseboard of our new autopilot product, NewBeeDrone Pixhawk 6X Pro.

Baseboard

HEX board ID: 0x300  
Board Name: NewBeeDrone Pixhawk 6X Baseboard  
Board Type: base  
Manufacturer Name: NewBeeDrone  
Manufacturer Email: support@newbeedrone.com  

IMU Board

HEX board ID: 0x300  
Board Name: NewBeeDrone FMUv6x revA  
Board Type: imu  
Manufacturer Name: NewBeeDrone  
Manufacturer Email: support@newbeedrone.com  

Note: The sensor configuration matches the CUAV v6x sensor set, so no new sensor-set definition is required.
<img width="706" height="817" alt="image" src="https://github.com/user-attachments/assets/0d188f42-6630-47e3-b7b5-07cce13877c2" />
